### PR TITLE
Fix IE, userfriendly, autosolve, directional lines

### DIFF
--- a/lyne-solver.css
+++ b/lyne-solver.css
@@ -91,7 +91,7 @@ article > section > textarea#puzzleinput {
 	font-size: 1.5em;
 	line-height: 1em;
 }
-article > section > output#messages {
+article > section > div#messages {
 	min-height: 1.1em;
 	line-height: 1.1em;
 	margin: 1ex 0;
@@ -123,4 +123,12 @@ article > section > svg#svgsolution {
 #svgsolutioncontainer > svg .edge {
 	stroke-width: 0.125px;
 	display: none;
+}
+
+#svgsolutioncontainer > svg .edge.edgewide {
+	stroke-width: 0.25px;
+}
+
+#autosolvelabel {
+	color: #FB8686;
 }

--- a/lyne-solver.html
+++ b/lyne-solver.html
@@ -110,9 +110,12 @@
  123hPH
 TdDSs</textarea>
 	<input type="button" id="solvebutton" value="Solve it!">
-	<output id="messages"></output>
+	<div id="messages"></div>
 	<label for="revealrange">Reveal:</label>
-	<input type="range" id="revealrange" value="0" min="0" step="1">
+	<input title="Slide to reveal more of the lines once the board has been solved." type="range" id="revealrange" value="0" min="0" step="1">
+	<br/>
+	<div><input type="checkbox" id="directional"><label title="Lines show the direction they're moving" for="directional">Directional</label></div>
+	<div><input type="checkbox" id="autosolve"><label title="Warning: Might make input unresponsive for large puzzles." id="autosolvelabel" for="autosolve">Autosolve</label></div>
 	<p><a href="https://github.com/denilsonsa/lyne-solver">Need help? Read more at GitHub.</a></p>
 </section>
 


### PR DESCRIPTION
I made most of these changes for my own purposes, you are welcome to them if it fits your vision.

Fixed IE compatibility by removing 'for of' loop and 'output' tag.

When the reveal bar is at the maximum, it will stay at the maximum until
changed by the user.

Added two optional features:
- Autosolve - Any changes to the board will attempt to be solved.
- Directional lines - When turned on, lines are thicker in one direction,
  to give a sense of which direction to go.

![lines](https://cloud.githubusercontent.com/assets/1232124/8381993/92308562-1bfd-11e5-84f3-40185389ad39.PNG)
